### PR TITLE
Optimize Whisper inference for faster transcription

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -124,7 +124,7 @@ class WhisperDictationApp(rumps.App):
         self.title = "🎙️ (Loading...)"
         self.status_item.title = "Status: Loading Whisper model..."
         try:
-            self.model = faster_whisper.WhisperModel("medium.en")
+            self.model = faster_whisper.WhisperModel("medium.en", compute_type="int8")
             self.title = "🎙️"
             self.status_item.title = "Status: Ready"
             logger.info("Whisper model loaded successfully!")
@@ -268,7 +268,7 @@ class WhisperDictationApp(rumps.App):
         
         # Transcribe with Whisper
         try:
-            segments, _ = self.model.transcribe(temp_filename, beam_size=5)
+            segments, _ = self.model.transcribe(temp_filename, beam_size=2, best_of=1, vad_filter=True)
             
             text = ""
             for segment in segments:


### PR DESCRIPTION
## Summary
- Use **int8 quantization** (`compute_type="int8"`) for the Whisper model to reduce memory usage and speed up loading
- Tune transcription parameters: reduce `beam_size` from 5 to 2, set `best_of=1`, and enable `vad_filter=True` to skip silent audio segments
- Overall goal: faster real-time dictation with minimal accuracy tradeoff

## Test plan
- [ ] Verify the app launches and the Whisper model loads without errors
- [ ] Record and transcribe audio to confirm transcription still produces accurate results
- [ ] Confirm reduced latency during transcription compared to previous settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)